### PR TITLE
feat: Implement team engagement features (Phase 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,6 @@ EXPENSE_REPORT_FORM_URL=https://docs.google.com/forms/d/your_form_id/viewform
 
 # Supabase/PostgreSQL Database URL
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE"
+
+# Festival Countdown
+FESTIVAL_START_DATE=2025-10-25

--- a/src/commands/achievements.ts
+++ b/src/commands/achievements.ts
@@ -1,0 +1,59 @@
+import { SlashCommandBuilder, CommandInteraction, EmbedBuilder } from 'discord.js';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('achievements')
+    .setDescription('Shows user achievements and contributions.')
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('view')
+        .setDescription('Views the achievements of a user.')
+        .addUserOption(option => option.setName('user').setDescription('The user to view (defaults to yourself)'))
+    ),
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.isChatInputCommand()) return;
+
+    const subcommand = interaction.options.getSubcommand();
+
+    if (subcommand === 'view') {
+      const targetUser = interaction.options.getUser('user') || interaction.user;
+
+      try {
+        await interaction.deferReply();
+
+        const [kudosGiven, kudosReceived, itemsReported, shifts] = await Promise.all([
+          prisma.kudos.count({ where: { fromUserId: targetUser.id } }),
+          prisma.kudos.count({ where: { toUserId: targetUser.id } }),
+          prisma.lostItem.count({ where: { reportedById: targetUser.id } }),
+          prisma.shift.findMany({ where: { assignees: { path: '$[*].id', array_contains: targetUser.id } } }), // This is complex and might not work on all DBs
+        ]);
+
+        // A more reliable way to count shifts, albeit less efficient if there are many shifts
+        const allShifts = await prisma.shift.findMany();
+        const shiftCount = allShifts.filter(shift =>
+            (shift.assignees as any[]).some(a => a.id === targetUser.id)
+        ).length;
+
+        const embed = new EmbedBuilder()
+          .setColor('#FFD700')
+          .setTitle(`${targetUser.username}'s Contributions`)
+          .setThumbnail(targetUser.displayAvatarURL())
+          .addFields(
+            { name: 'Kudos Given', value: `**${kudosGiven}** times`, inline: true },
+            { name: 'Kudos Received', value: `**${kudosReceived}** times`, inline: true },
+            { name: 'Shifts Worked', value: `**${shiftCount}** times`, inline: true },
+            { name: 'Lost Items Reported', value: `**${itemsReported}** items`, inline: true }
+          )
+          .setTimestamp();
+
+        await interaction.editReply({ embeds: [embed] });
+      } catch (error) {
+        console.error('Achievements command error:', error);
+        await interaction.editReply({ content: 'An error occurred while fetching achievements.', ephemeral: true });
+      }
+    }
+  },
+};

--- a/src/commands/countdown.ts
+++ b/src/commands/countdown.ts
@@ -1,0 +1,37 @@
+import { SlashCommandBuilder, CommandInteraction, EmbedBuilder } from 'discord.js';
+
+const festivalDateStr = process.env.FESTIVAL_START_DATE;
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('countdown')
+    .setDescription('Shows the countdown to the festival.'),
+  async execute(interaction: CommandInteraction) {
+    if (!festivalDateStr) {
+      await interaction.reply({ content: 'The festival start date is not configured.', ephemeral: true });
+      return;
+    }
+
+    const festivalDate = new Date(festivalDateStr);
+    const now = new Date();
+
+    const diff = festivalDate.getTime() - now.getTime();
+
+    if (diff <= 0) {
+      await interaction.reply('The festival is already happening or has passed! 🎉');
+      return;
+    }
+
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+    const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+    const embed = new EmbedBuilder()
+        .setColor('#57F287')
+        .setTitle('文化祭開催まであと...')
+        .setDescription(`**${days}**日 **${hours}**時間 **${minutes}**分 **${seconds}**秒`);
+
+    await interaction.reply({ embeds: [embed] });
+  },
+};

--- a/src/commands/kudos.ts
+++ b/src/commands/kudos.ts
@@ -1,0 +1,96 @@
+import { SlashCommandBuilder, CommandInteraction, EmbedBuilder } from 'discord.js';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('kudos')
+    .setDescription('Give kudos to a team member.')
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('give')
+        .setDescription('Give kudos to someone for their hard work.')
+        .addUserOption(option => option.setName('user').setDescription('The user to give kudos to').setRequired(true))
+        .addStringOption(option => option.setName('message').setDescription('Your message of appreciation').setRequired(true))
+    )
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('top')
+        .setDescription('Shows the kudos leaderboard.')
+    ),
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.isChatInputCommand()) return;
+
+    const subcommand = interaction.options.getSubcommand();
+
+    try {
+      if (subcommand === 'give') {
+        const targetUser = interaction.options.getUser('user', true);
+        const message = interaction.options.getString('message', true);
+
+        if (targetUser.id === interaction.user.id) {
+          await interaction.reply({ content: 'You cannot give kudos to yourself!', ephemeral: true });
+          return;
+        }
+
+        await prisma.kudos.create({
+          data: {
+            fromUserId: interaction.user.id,
+            toUserId: targetUser.id,
+            message: message,
+          },
+        });
+
+        const embed = new EmbedBuilder()
+          .setColor('#FEE75C')
+          .setTitle(`👏 Kudos for ${targetUser.username}!`)
+          .setDescription(`**${interaction.user.username}** gave kudos to **${targetUser.username}**:`)
+          .addFields({ name: 'Message', value: message })
+          .setThumbnail(targetUser.displayAvatarURL())
+          .setTimestamp();
+
+        await interaction.reply({ embeds: [embed] });
+      } else if (subcommand === 'top') {
+        const topReceivers = await prisma.kudos.groupBy({
+          by: ['toUserId'],
+          _count: {
+            toUserId: true,
+          },
+          orderBy: {
+            _count: {
+              toUserId: 'desc',
+            },
+          },
+          take: 5,
+        });
+
+        if (topReceivers.length === 0) {
+          await interaction.reply('No kudos have been given yet.');
+          return;
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor('#FEE75C')
+            .setTitle('🏆 Kudos Leaderboard');
+
+        const leaderboardEntries = await Promise.all(
+            topReceivers.map(async (receiver, index) => {
+                try {
+                    const user = await interaction.client.users.fetch(receiver.toUserId);
+                    return `${index + 1}. **${user.username}** - ${receiver._count.toUserId} kudos`;
+                } catch {
+                    return `${index + 1}. **Unknown User** - ${receiver._count.toUserId} kudos`;
+                }
+            })
+        );
+
+        embed.setDescription(leaderboardEntries.join('\n'));
+        await interaction.reply({ embeds: [embed] });
+      }
+    } catch (error) {
+      console.error('Kudos command error:', error);
+      await interaction.reply({ content: 'An error occurred while handling kudos.', ephemeral: true });
+    }
+  },
+};

--- a/src/commands/poll.ts
+++ b/src/commands/poll.ts
@@ -1,0 +1,96 @@
+import { SlashCommandBuilder, CommandInteraction, EmbedBuilder, TextChannel } from 'discord.js';
+
+const choiceEmojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟'];
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('poll')
+    .setDescription('Creates and manages polls.')
+    .addSubcommand(subcommand => {
+      subcommand
+        .setName('create')
+        .setDescription('Creates a new poll.')
+        .addStringOption(option => option.setName('question').setDescription('The poll question').setRequired(true));
+      // Add up to 10 choices
+      for (let i = 1; i <= 10; i++) {
+        subcommand.addStringOption(option => option.setName(`choice${i}`).setDescription(`Choice ${i}`).setRequired(i <= 2));
+      }
+      return subcommand;
+    })
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('close')
+        .setDescription('Closes a poll and shows the results.')
+        .addStringOption(option => option.setName('message_id').setDescription('The message ID of the poll to close').setRequired(true))
+    ),
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.isChatInputCommand() || !interaction.channel) return;
+
+    const subcommand = interaction.options.getSubcommand();
+
+    try {
+      if (subcommand === 'create') {
+        const question = interaction.options.getString('question', true);
+        const choices = [];
+        for (let i = 1; i <= 10; i++) {
+          const choice = interaction.options.getString(`choice${i}`);
+          if (choice) {
+            choices.push(choice);
+          }
+        }
+
+        const embed = new EmbedBuilder()
+          .setColor('#3498DB')
+          .setTitle(question)
+          .setDescription(choices.map((c, i) => `${choiceEmojis[i]} ${c}`).join('\n'));
+
+        const pollMessage = await interaction.reply({ embeds: [embed], fetchReply: true });
+
+        for (let i = 0; i < choices.length; i++) {
+          await pollMessage.react(choiceEmojis[i]);
+        }
+      } else if (subcommand === 'close') {
+        const messageId = interaction.options.getString('message_id', true);
+
+        const pollMessage = await interaction.channel.messages.fetch(messageId);
+        if (!pollMessage || pollMessage.author.id !== interaction.client.user.id) {
+            await interaction.reply({ content: 'Could not find a valid poll with that message ID.', ephemeral: true});
+            return;
+        }
+
+        const pollEmbed = pollMessage.embeds[0];
+        if (!pollEmbed) {
+            await interaction.reply({ content: 'The specified message does not contain a valid poll embed.', ephemeral: true});
+            return;
+        }
+
+        const results = [];
+        const choices = pollEmbed.description?.split('\n') || [];
+
+        for (const line of choices) {
+            const emoji = line.match(/([\u{1f1e6}-\u{1f1ff}\u{1f300}-\u{1f5ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f900}-\u{1f9ff}\u{1f018}-\u{1f270}])/u);
+            if (emoji) {
+                const reaction = pollMessage.reactions.cache.get(emoji[0]);
+                const count = reaction ? reaction.count - 1 : 0; // Subtract bot's own reaction
+                results.push({ choice: line, count });
+            }
+        }
+
+        results.sort((a, b) => b.count - a.count);
+
+        const resultsEmbed = new EmbedBuilder()
+            .setColor('#992D22')
+            .setTitle(`Results for: ${pollEmbed.title}`)
+            .setDescription(results.map(r => `${r.choice}: **${r.count} votes**`).join('\n'));
+
+        await interaction.reply({ embeds: [resultsEmbed] });
+
+        const closedEmbed = EmbedBuilder.from(pollEmbed).setFooter({text: 'This poll is now closed.'});
+        await pollMessage.edit({ embeds: [closedEmbed] });
+      }
+    } catch (error) {
+      console.error('Poll command error:', error);
+      await interaction.reply({ content: 'An error occurred while handling the poll.', ephemeral: true });
+    }
+  },
+};


### PR DESCRIPTION
This commit introduces the team engagement features as defined in Phase 3 of the development plan. These features are designed to boost team morale and streamline group decision-making.

- **Kudos (`/kudos`):**
  - Adds a new `/kudos` command with `give` and `top` subcommands.
  - Allows members to give public appreciation to others, which is stored in the database.
  - The `top` subcommand displays a leaderboard of the most appreciated members.

- **Polls (`/poll`):**
  - Adds a new `/poll` command with `create` and `close` subcommands.
  - `/create` generates a poll with up to 10 choices using reaction buttons.
  - `/close` fetches a poll message, tallies the reactions, and posts the results.

- **Countdown (`/countdown`):**
  - Adds a new `/countdown` command that displays the time remaining until the festival start date, which is configured via an environment variable.

- **Achievements (`/achievements`):**
  - Adds a new `/achievements` command with a `view` subcommand.
  - It fetches and aggregates a user's contributions across various modules (shifts worked, kudos given/received, items reported) and displays them as a summary.