### PR TITLE
feat: Implement /build command for declarative server configuration

### DIFF
--- a/prisma/migrations/20250826230200_add_build_models/migration.sql
+++ b/prisma/migrations/20250826230200_add_build_models/migration.sql
@@ -1,0 +1,27 @@
+-- CreateSchema
+-- CreateTable
+CREATE TABLE "public"."Template" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Template_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."BuildRun" (
+    "id" TEXT NOT NULL,
+    "templateName" TEXT NOT NULL,
+    "dryRunResult" JSONB NOT NULL,
+    "snapshot" JSONB NOT NULL,
+    "status" TEXT NOT NULL,
+    "executedBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BuildRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Template_name_key" ON "public"."Template"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,3 +60,21 @@ model CongestionReport {
 
   @@index([location, createdAt])
 }
+
+model Template {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  content   Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model BuildRun {
+  id           String   @id @default(cuid())
+  templateName String
+  dryRunResult Json
+  snapshot     Json
+  status       String // PENDING, SUCCESS, FAILED
+  executedBy   String
+  createdAt    DateTime @default(now())
+}

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,0 +1,127 @@
+import { SlashCommandBuilder, CommandInteraction, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType } from 'discord.js';
+import { getGuildState, GuildState } from '../services/discordService';
+import { diffTemplate, DiffResult } from '../services/diffService';
+import { executeBuild } from '../services/executionService';
+import { ServerTemplate } from '../types/template';
+import * as fs from 'fs/promises';
+import path from 'path';
+
+function formatDiffPreview(diff: DiffResult, templateName: string): EmbedBuilder {
+    const embed = new EmbedBuilder()
+        .setColor('#3498DB')
+        .setTitle(`Template Dry-Run: '${templateName}'`)
+        .setDescription('Review the following changes before applying the template. This is a preview and no changes have been made yet.')
+        .setTimestamp();
+
+    const rolesToCreate = diff.roles.toCreate.map(r => `\`+ ${r.name}\``).join('\n') || 'None';
+    const rolesToUpdate = diff.roles.toUpdate.map(r => `\`~ ${r.existing.name}\``).join('\n') || 'None';
+    if (diff.roles.toCreate.length > 0 || diff.roles.toUpdate.length > 0) {
+        embed.addFields(
+            { name: 'Roles to Create', value: rolesToCreate, inline: true },
+            { name: 'Roles to Update', value: rolesToUpdate, inline: true }
+        );
+    }
+
+    const catsToCreate = diff.categories.toCreate.map(c => `\`+ ${c.name}\``).join('\n') || 'None';
+    if (diff.categories.toCreate.length > 0) {
+        embed.addFields({ name: 'Categories to Create', value: catsToCreate });
+    }
+
+    const chansToCreate = diff.channels.toCreate.map(c => `\`+ #${c.channel.name}\` (in ${c.categoryName})`).join('\n') || 'None';
+     if (diff.channels.toCreate.length > 0) {
+        embed.addFields({ name: 'Channels to Create', value: chansToCreate });
+    }
+
+    if (embed.data.fields?.length === 0) {
+        embed.setDescription('✅ No changes detected. The server configuration already matches the template.');
+    }
+
+    return embed;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('build')
+    .setDescription('Manages the server build based on a template.')
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('apply')
+        .setDescription('Applies a server template (shows a preview first).')
+        .addStringOption(option =>
+          option.setName('name')
+            .setDescription('The name of the template to apply.')
+            .setRequired(true)
+            .addChoices(
+                { name: 'standard', value: 'standard' }
+            )
+        )
+    ),
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.isChatInputCommand() || !interaction.guild) return;
+
+    if (interaction.options.getSubcommand() === 'apply') {
+        const templateName = interaction.options.getString('name', true);
+        await interaction.reply({ content: `Request received for template **${templateName}**. Generating preview...`, ephemeral: true });
+
+        let diff: DiffResult;
+        let currentState: GuildState;
+
+        try {
+            // 1. Load template and calculate diff
+            const templatePath = path.resolve(process.cwd(), 'template.json');
+            const templateFile = await fs.readFile(templatePath, 'utf-8');
+            const template: ServerTemplate = JSON.parse(templateFile);
+            currentState = await getGuildState(interaction.guild);
+            diff = diffTemplate(currentState, template);
+
+            // 2. Format and send the preview
+            const previewEmbed = formatDiffPreview(diff, templateName);
+            const actionRow = new ActionRowBuilder<ButtonBuilder>()
+                .addComponents(
+                    new ButtonBuilder().setCustomId('build-confirm').setLabel('Apply Changes').setStyle(ButtonStyle.Success),
+                    new ButtonBuilder().setCustomId('build-cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary)
+                );
+
+            const response = await interaction.editReply({
+                content: ``,
+                embeds: [previewEmbed],
+                components: [actionRow]
+            });
+
+            // 3. Wait for button interaction
+            const collector = response.createMessageComponentCollector({ componentType: ComponentType.Button, time: 60_000 });
+
+            collector.on('collect', async i => {
+                if (i.user.id !== interaction.user.id) {
+                    await i.reply({ content: 'You cannot use these buttons.', ephemeral: true });
+                    return;
+                }
+
+                collector.stop();
+                if (i.customId === 'build-confirm') {
+                    try {
+                        await i.update({ content: 'Applying changes...', embeds: [], components: [] });
+                        await executeBuild(interaction.guild!, diff, currentState, templateName, i.user.id);
+                        await i.editReply({ content: '✅ Build successful! The template has been applied.'});
+                    } catch (error) {
+                        console.error("Error during build execution:", error);
+                        await i.editReply({ content: '❌ An error occurred during execution. Please check the logs.' });
+                    }
+                } else if (i.customId === 'build-cancel') {
+                    await i.update({ content: 'Operation cancelled.', embeds: [], components: [] });
+                }
+            });
+
+            collector.on('end', (collected, reason) => {
+                if (reason === 'time') {
+                    interaction.editReply({ content: 'Confirmation timed out.', embeds: [], components: [] });
+                }
+            });
+
+        } catch (error) {
+            console.error("Error during preview generation:", error);
+            await interaction.editReply({ content: 'An error occurred while generating the preview.', embeds:[], components: [] });
+        }
+    }
+  },
+};

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+/**
+ * A singleton instance of the Prisma Client.
+ * This should be used throughout the application to interact with the database.
+ */
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -1,0 +1,173 @@
+import { ChannelType } from 'discord.js';
+import { ServerTemplate, TemplateCategory, TemplateChannel, TemplateRole, TemplateRoleOverwrite } from '../types/template';
+import { GuildState, SimpleChannel, SimpleOverwrite, SimpleRole } from './discordService';
+
+// --- Utility Functions ---
+
+/**
+ * Converts a hex color string to a decimal number.
+ * @param hex The hex color string (e.g., "#RRGGBB").
+ * @returns The color as a decimal number.
+ */
+function hexToNumber(hex: string): number {
+    return parseInt(hex.startsWith('#') ? hex.substring(1) : hex, 16);
+}
+
+
+// --- Diffing Interfaces ---
+
+export interface RoleDiff {
+    toCreate: TemplateRole[];
+    toUpdate: { existing: SimpleRole; changes: Partial<TemplateRole> }[];
+    toSkip: SimpleRole[];
+}
+
+export interface CategoryDiff {
+    toCreate: TemplateCategory[];
+    toSkip: SimpleChannel[];
+}
+
+export interface ChannelDiff {
+    toCreate: { channel: TemplateChannel; categoryName: string }[];
+    toUpdate: { existing: SimpleChannel; changes: Partial<TemplateChannel>; categoryName: string }[];
+    toSkip: SimpleChannel[];
+}
+
+export interface DiffResult {
+    roles: RoleDiff;
+    categories: CategoryDiff;
+    channels: ChannelDiff;
+}
+
+// --- Main Diffing Logic ---
+
+/**
+ * Compares the server template with the current guild state to determine changes.
+ * @param currentState The current state of the guild.
+ * @param template The desired state from the template file.
+ * @returns An object detailing what needs to be created, updated, or skipped.
+ */
+export function diffTemplate(currentState: GuildState, template: ServerTemplate): DiffResult {
+    const result: DiffResult = {
+        roles: { toCreate: [], toUpdate: [], toSkip: [] },
+        categories: { toCreate: [], toSkip: [] },
+        channels: { toCreate: [], toUpdate: [], toSkip: [] },
+    };
+
+    diffRoles(currentState, template, result);
+    diffCategoriesAndChannels(currentState, template, result);
+
+    return result;
+}
+
+function diffRoles(currentState: GuildState, template: ServerTemplate, result: DiffResult) {
+    template.roles?.forEach(templateRole => {
+        const existingRole = currentState.roles.get(templateRole.name);
+        if (!existingRole) {
+            result.roles.toCreate.push(templateRole);
+        } else {
+            // For now, we just check for existence. Update logic will be added later.
+            // A simple check for color difference:
+            const changes: Partial<TemplateRole> = {};
+            if (templateRole.color && hexToNumber(templateRole.color) !== existingRole.color) {
+                changes.color = templateRole.color;
+            }
+             if (templateRole.hoist !== undefined && templateRole.hoist !== existingRole.hoist) {
+                changes.hoist = templateRole.hoist;
+            }
+            if (templateRole.mentionable !== undefined && templateRole.mentionable !== existingRole.mentionable) {
+                changes.mentionable = templateRole.mentionable;
+            }
+
+            if (Object.keys(changes).length > 0) {
+                result.roles.toUpdate.push({ existing: existingRole, changes });
+            } else {
+                result.roles.toSkip.push(existingRole);
+            }
+        }
+    });
+}
+
+function areOverwritesEqual(templateOverwrites: TemplateRoleOverwrite[] = [], existingOverwrites: SimpleOverwrite[] = []): boolean {
+    if (templateOverwrites.length !== existingOverwrites.length) return false;
+
+    const existingMap = new Map<string, { allow: Set<string>, deny: Set<string> }>();
+    existingOverwrites.forEach(o => {
+        existingMap.set(o.roleName, {
+            allow: new Set(o.allow),
+            deny: new Set(o.deny),
+        });
+    });
+
+    for (const tplOverwrite of templateOverwrites) {
+        const existingO = existingMap.get(tplOverwrite.role);
+        if (!existingO) return false;
+
+        const tplAllow = new Set(tplOverwrite.allow || []);
+        const tplDeny = new Set(tplOverwrite.deny || []);
+
+        if (tplAllow.size !== existingO.allow.size || tplDeny.size !== existingO.deny.size) return false;
+
+        for (const p of tplAllow) if (!existingO.allow.has(p)) return false;
+        for (const p of tplDeny) if (!existingO.deny.has(p)) return false;
+    }
+
+    return true;
+}
+
+
+function diffCategoriesAndChannels(currentState: GuildState, template: ServerTemplate, result: DiffResult) {
+    const existingCategories = new Map<string, SimpleChannel>();
+    const existingChannelsByParent = new Map<string, SimpleChannel[]>();
+
+    currentState.channels.forEach(channel => {
+        if (channel.type === ChannelType.GuildCategory) {
+            existingCategories.set(channel.name, channel);
+        } else if (channel.parentId) {
+            const channels = existingChannelsByParent.get(channel.parentId) || [];
+            channels.push(channel);
+            existingChannelsByParent.set(channel.parentId, channels);
+        }
+    });
+
+    template.categories?.forEach(templateCategory => {
+        const existingCategory = existingCategories.get(templateCategory.name);
+        if (!existingCategory) {
+            // If category doesn't exist, all its channels are new
+            result.categories.toCreate.push(templateCategory);
+            templateCategory.channels.forEach(channel => {
+                result.channels.toCreate.push({ channel, categoryName: templateCategory.name });
+            });
+        } else {
+            // Category exists, so skip it and diff its channels
+            result.categories.toSkip.push(existingCategory);
+            const childChannels = existingChannelsByParent.get(existingCategory.id) || [];
+            const childChannelsMap = new Map(childChannels.map(c => [c.name, c]));
+
+            templateCategory.channels.forEach(templateChannel => {
+                const existingChannel = childChannelsMap.get(templateChannel.name);
+                if (!existingChannel) {
+                    result.channels.toCreate.push({ channel: templateChannel, categoryName: templateCategory.name });
+                } else {
+                    const changes: Partial<TemplateChannel> = {};
+
+                    // Compare topic
+                    if (templateChannel.topic !== undefined && templateChannel.topic !== existingChannel.topic) {
+                        changes.topic = templateChannel.topic;
+                    }
+
+                    // Compare overwrites
+                    if (!areOverwritesEqual(templateChannel.overwrites, existingChannel.overwrites)) {
+                        changes.overwrites = templateChannel.overwrites;
+                    }
+
+                    if (Object.keys(changes).length > 0) {
+                        result.channels.toUpdate.push({ existing: existingChannel, changes, categoryName: templateCategory.name });
+                    } else {
+                        result.channels.toSkip.push(existingChannel);
+                    }
+                }
+            });
+        }
+    });
+}

--- a/src/services/discordService.ts
+++ b/src/services/discordService.ts
@@ -1,0 +1,100 @@
+import { Guild, Role, ChannelType, TextChannel, VoiceChannel, CategoryChannel, PermissionOverwriteManager, PermissionFlags, PermissionsBitField } from 'discord.js';
+
+// A simplified representation of a role for diffing purposes
+export interface SimpleRole {
+    id: string;
+    name: string;
+    color: number;
+    hoist: boolean;
+    mentionable: boolean;
+}
+
+export interface SimpleOverwrite {
+    roleName: string;
+    allow: string[];
+    deny: string[];
+}
+
+// A simplified representation of a channel for diffing purposes
+export interface SimpleChannel {
+    id: string;
+    name: string;
+    type: ChannelType.GuildText | ChannelType.GuildVoice | ChannelType.GuildCategory;
+    topic?: string | null;
+    parentId: string | null;
+    overwrites: SimpleOverwrite[];
+}
+
+// The overall state of the guild relevant for the template
+export interface GuildState {
+    roles: Map<string, SimpleRole>;
+    channels: Map<string, SimpleChannel>;
+}
+
+/**
+ * Fetches the current state of the guild (roles and channels) from Discord.
+ * @param guild The discord.js Guild object.
+ * @returns A promise that resolves to a structured representation of the guild's state.
+ */
+export async function getGuildState(guild: Guild): Promise<GuildState> {
+    const state: GuildState = {
+        roles: new Map(),
+        channels: new Map(),
+    };
+
+    // 1. Fetch all roles from the guild
+    const guildRoles = await guild.roles.fetch();
+    guildRoles.forEach(role => {
+        // We ignore the @everyone role as it's not typically managed by templates in this way
+        if (role.name !== '@everyone') {
+            state.roles.set(role.name, {
+                id: role.id,
+                name: role.name,
+                color: role.color,
+                hoist: role.hoist,
+                mentionable: role.mentionable,
+            });
+        }
+    });
+
+    // Create a map of role IDs to names for easy lookup
+    const roleIdToName = new Map<string, string>();
+    guildRoles.forEach(role => roleIdToName.set(role.id, role.name));
+    // Also add @everyone
+    const everyoneRole = guild.roles.everyone;
+    roleIdToName.set(everyoneRole.id, everyoneRole.name);
+
+    // 2. Fetch all channels from the guild
+    const guildChannels = await guild.channels.fetch();
+    guildChannels.forEach(channel => {
+        // We only care about text, voice, and category channels as defined in the template
+        if (channel && (channel.type === ChannelType.GuildText || channel.type === ChannelType.GuildVoice || channel.type === ChannelType.GuildCategory)) {
+
+            const simpleOverwrites: SimpleOverwrite[] = [];
+            channel.permissionOverwrites.cache.forEach(overwrite => {
+                // We only care about role overwrites for now
+                if (overwrite.type === 0) { // 0 for 'role'
+                    const roleName = roleIdToName.get(overwrite.id);
+                    if (roleName) {
+                        simpleOverwrites.push({
+                            roleName: roleName,
+                            allow: new PermissionsBitField(overwrite.allow).toArray(),
+                            deny: new PermissionsBitField(overwrite.deny).toArray(),
+                        });
+                    }
+                }
+            });
+
+            state.channels.set(channel.name, {
+                id: channel.id,
+                name: channel.name,
+                type: channel.type,
+                topic: channel.type === ChannelType.GuildText ? channel.topic : null,
+                parentId: channel.parentId,
+                overwrites: simpleOverwrites,
+            });
+        }
+    });
+
+    return state;
+}

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -1,0 +1,140 @@
+import { ChannelType, Guild, OverwriteResolvable, PermissionsString } from 'discord.js';
+import prisma from '../prisma';
+import { TemplateRoleOverwrite } from '../types/template';
+import { DiffResult } from './diffService';
+import { GuildState } from './discordService';
+
+// --- Utility ---
+function hexToNumber(hex: string): number {
+    return parseInt(hex.startsWith('#') ? hex.substring(1) : hex, 16);
+}
+
+async function mapOverwrites(guild: Guild, templateOverwrites: TemplateRoleOverwrite[] = []): Promise<OverwriteResolvable[]> {
+    const results: OverwriteResolvable[] = [];
+    // Ensure all roles are fetched into the cache
+    await guild.roles.fetch();
+
+    for (const overwrite of templateOverwrites) {
+        let roleId: string | undefined;
+        if (overwrite.role === '@everyone') {
+            roleId = guild.roles.everyone.id;
+        } else {
+            const role = guild.roles.cache.find(r => r.name === overwrite.role);
+            roleId = role?.id;
+        }
+
+        if (roleId) {
+            results.push({
+                id: roleId,
+                allow: overwrite.allow as PermissionsString[],
+                deny: overwrite.deny as PermissionsString[],
+            });
+        } else {
+            console.warn(`Could not find role '${overwrite.role}' for permission overwrite. Skipping.`);
+        }
+    }
+    return results;
+}
+
+/**
+ * Executes the changes determined by the diffing service.
+ * @param guild The guild to apply changes to.
+ * @param diff The diff result from the diffing service.
+ * @param currentState The state of the guild before changes, used for snapshotting.
+ * @param templateName The name of the template being applied.
+ * @param userId The ID of the user who initiated the build.
+ */
+export async function executeBuild(guild: Guild, diff: DiffResult, currentState: GuildState, templateName: string, userId: string) {
+    // 1. Create a snapshot and a BuildRun record
+    const buildRun = await prisma.buildRun.create({
+        data: {
+            templateName: templateName,
+            executedBy: userId,
+            status: 'PENDING',
+            snapshot: currentState as any, // Cast to any to satisfy Prisma's JsonValue
+            dryRunResult: diff as any,
+        },
+    });
+
+    try {
+        // --- Execution Phase ---
+        // The order of operations is important to handle dependencies (roles -> categories -> channels)
+
+        // 2. Execute Role Changes
+        for (const roleToCreate of diff.roles.toCreate) {
+            await guild.roles.create({
+                name: roleToCreate.name,
+                color: roleToCreate.color ? hexToNumber(roleToCreate.color) : undefined,
+                hoist: roleToCreate.hoist,
+                mentionable: roleToCreate.mentionable,
+                permissions: [], // Permissions are handled via overwrites, not on the role itself
+            });
+        }
+        for (const roleToUpdate of diff.roles.toUpdate) {
+             await guild.roles.edit(roleToUpdate.existing.id, {
+                color: roleToUpdate.changes.color ? hexToNumber(roleToUpdate.changes.color) : undefined,
+                hoist: roleToUpdate.changes.hoist,
+                mentionable: roleToUpdate.changes.mentionable
+            });
+        }
+
+        // 3. Execute Category and Channel Changes
+        const createdCategories = new Map<string, string>(); // Map from template category name to created category ID
+
+        for (const categoryToCreate of diff.categories.toCreate) {
+            const newCategory = await guild.channels.create({
+                name: categoryToCreate.name,
+                type: ChannelType.GuildCategory,
+            });
+            createdCategories.set(categoryToCreate.name, newCategory.id);
+        }
+
+        for (const channelToCreate of diff.channels.toCreate) {
+            // Find parent category ID
+            const parentCategory = guild.channels.cache.find(c => c.name === channelToCreate.categoryName && c.type === ChannelType.GuildCategory);
+            const parentId = parentCategory?.id ?? createdCategories.get(channelToCreate.categoryName);
+
+            if (!parentId) {
+                console.warn(`Could not find or create parent category '${channelToCreate.categoryName}' for channel '#${channelToCreate.channel.name}'. Skipping.`);
+                continue;
+            }
+
+            const permissionOverwrites = await mapOverwrites(guild, channelToCreate.channel.overwrites);
+
+            await guild.channels.create({
+                name: channelToCreate.channel.name,
+                type: channelToCreate.channel.type === 'text' ? ChannelType.GuildText : ChannelType.GuildVoice,
+                topic: channelToCreate.channel.topic,
+                parent: parentId,
+                permissionOverwrites,
+            });
+        }
+
+        // 4. Execute Channel Updates
+        for (const channelToUpdate of diff.channels.toUpdate) {
+            const channel = guild.channels.cache.get(channelToUpdate.existing.id);
+            if (channel && 'edit' in channel) {
+                const newOverwrites = await mapOverwrites(guild, channelToUpdate.changes.overwrites);
+                await channel.edit({
+                    topic: channelToUpdate.changes.topic,
+                    permissionOverwrites: newOverwrites,
+                });
+            }
+        }
+
+        // 4. If all successful, update the build run status
+        await prisma.buildRun.update({
+            where: { id: buildRun.id },
+            data: { status: 'SUCCESS' },
+        });
+
+    } catch (error) {
+        // 5. If an error occurs, update the status and re-throw
+        await prisma.buildRun.update({
+            where: { id: buildRun.id },
+            data: { status: 'FAILED' },
+        });
+        // Re-throw the error to be caught by the command handler
+        throw error;
+    }
+}

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,0 +1,37 @@
+/**
+ * This file contains the TypeScript type definitions for the server template JSON format.
+ * These interfaces are used to ensure type safety when reading and processing the template.
+ */
+
+export interface TemplateRoleOverwrite {
+  role: string; // Role name, e.g., "@everyone" or "実行委員"
+  allow: string[]; // Array of permission flags, e.g., "SEND_MESSAGES"
+  deny: string[];
+}
+
+export interface TemplateChannel {
+  name: string;
+  type: 'text' | 'voice' | 'forum'; // As per design doc
+  topic?: string;
+  bitrate?: number;
+  overwrites?: TemplateRoleOverwrite[];
+}
+
+export interface TemplateCategory {
+  name: string;
+  channels: TemplateChannel[];
+}
+
+export interface TemplateRole {
+  name: string;
+  color?: string; // Hex string like "#3498DB"
+  hoist?: boolean;
+  mentionable?: boolean;
+}
+
+export interface ServerTemplate {
+  version: string;
+  name:string;
+  roles?: TemplateRole[];
+  categories?: TemplateCategory[];
+}

--- a/template.json
+++ b/template.json
@@ -1,0 +1,87 @@
+{
+  "version": "1",
+  "name": "標準テンプレート",
+  "roles": [
+    {
+      "name": "実行委員",
+      "color": "#3498DB",
+      "hoist": true,
+      "mentionable": true
+    },
+    {
+      "name": "1年生",
+      "color": "#2ECC71"
+    },
+    {
+      "name": "2年生",
+      "color": "#F1C40F"
+    },
+    {
+      "name": "3年生",
+      "color": "#E74C3C"
+    }
+  ],
+  "categories": [
+    {
+      "name": "運営本部",
+      "channels": [
+        {
+          "name": "全体連絡",
+          "type": "text",
+          "topic": "実行委員向けの全体連絡チャンネルです。"
+        },
+        {
+          "name": "アナウンス",
+          "type": "text",
+          "topic": "Botによる自動通知や重要告知が投稿されます。",
+          "overwrites": [
+            {
+              "role": "@everyone",
+              "deny": ["SEND_MESSAGES"],
+              "allow": ["VIEW_CHANNEL", "READ_MESSAGE_HISTORY"]
+            },
+            {
+              "role": "実行委員",
+              "allow": ["SEND_MESSAGES"]
+            }
+          ]
+        },
+        {
+          "name": "議事録",
+          "type": "text",
+          "topic": "AIによる議事録の要約が自動投稿されます。"
+        },
+        {
+          "name": "会議室",
+          "type": "voice",
+          "bitrate": 64000
+        }
+      ]
+    },
+    {
+      "name": "各係連絡",
+      "channels": [
+        {
+          "name": "企画係",
+          "type": "text",
+          "topic": "企画係の連絡・相談用チャンネルです。"
+        },
+        {
+          "name": "広報係",
+          "type": "text",
+          "topic": "広報係の連絡・相談用チャンネルです。"
+        },
+        {
+          "name": "会計係",
+          "type": "text",
+          "topic": "会計係の連絡・相談用チャンネルです。"
+        },
+        {
+          "name": "資材・警備係",
+          "type": "text",
+          "topic": "資材係と警備係の連絡・相談用チャンネルです。"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This commit introduces the new `/build` command, a core feature from the "Ritsu v2" design document. It allows server administrators to configure roles, categories, and channels declaratively using a JSON template.

Key features include:
- A `/build apply` command that reads a configuration from `template.json`.
- A dry-run preview that shows a diff of proposed changes (creations and updates) in an embed before any action is taken.
- User confirmation via buttons is required to proceed with the execution.
- A suite of new services to support this feature:
  - `discordService`: Fetches the current state of the guild's roles and channels, including permission overwrites.
  - `diffService`: Compares the template with the current state to produce a detailed diff.
  - `executionService`: Applies the diff to the guild in the correct dependency order (roles, then categories, then channels).
- New Prisma models (`Template`, `BuildRun`) and a corresponding database migration to store templates and log build history, including a snapshot of the server state for future rollback capabilities.