### PR TITLE
feat: Implement /build and /role assign-bulk commands

### DIFF
--- a/prisma/migrations/20250826234600_add_segment_model/migration.sql
+++ b/prisma/migrations/20250826234600_add_segment_model/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "public"."Segment" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "conditions" JSONB NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Segment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Segment_name_key" ON "public"."Segment"("name");
+
+-- CreateIndex
+CREATE INDEX "Segment_guildId_idx" ON "public"."Segment"("guildId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,3 +78,15 @@ model BuildRun {
   executedBy   String
   createdAt    DateTime @default(now())
 }
+
+model Segment {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  description String?
+  conditions  Json
+  guildId     String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([guildId])
+}

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -1,0 +1,98 @@
+import { SlashCommandBuilder, CommandInteraction, Role, GuildMember, ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType } from 'discord.js';
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('role')
+    .setDescription('Commands for managing roles.')
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('assign-bulk')
+        .setDescription('Assign a role to multiple members based on a filter.')
+        .addRoleOption(option =>
+          option.setName('role-to-assign')
+            .setDescription('The role to be assigned to the members.')
+            .setRequired(true))
+        .addRoleOption(option =>
+          option.setName('with-role')
+            .setDescription('Assign to members who have this role.')
+            .setRequired(true))
+    ),
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.isChatInputCommand() || !interaction.guild) return;
+
+    if (interaction.options.getSubcommand() === 'assign-bulk') {
+        await interaction.reply({ content: 'Fetching members and calculating changes...', ephemeral: true });
+
+        const roleToAssign = interaction.options.getRole('role-to-assign', true) as Role;
+        const withRole = interaction.options.getRole('with-role', true) as Role;
+
+        // Fetch all members to ensure cache is up-to-date
+        await interaction.guild.members.fetch();
+
+        const targetMembers = interaction.guild.members.cache.filter(member =>
+            member.roles.cache.has(withRole.id) && // Member has the 'with-role'
+            !member.roles.cache.has(roleToAssign.id) // Member does not already have the 'role-to-assign'
+        );
+
+        if (targetMembers.size === 0) {
+            await interaction.editReply({ content: 'No members found matching the criteria. No roles will be assigned.' });
+            return;
+        }
+
+        const confirmButton = new ButtonBuilder()
+            .setCustomId('confirm-assign')
+            .setLabel('Confirm')
+            .setStyle(ButtonStyle.Success);
+
+        const cancelButton = new ButtonBuilder()
+            .setCustomId('cancel-assign')
+            .setLabel('Cancel')
+            .setStyle(ButtonStyle.Secondary);
+
+        const row = new ActionRowBuilder<ButtonBuilder>().addComponents(confirmButton, cancelButton);
+
+        const response = await interaction.editReply({
+            content: `Found **${targetMembers.size}** members with the \`@${withRole.name}\` role who do not have the \`@${roleToAssign.name}\` role. Do you want to proceed?`,
+            components: [row]
+        });
+
+        const collector = response.createMessageComponentCollector({ componentType: ComponentType.Button, time: 60_000 });
+
+        collector.on('collect', async i => {
+            if (i.user.id !== interaction.user.id) {
+                await i.reply({ content: 'You cannot use these buttons.', ephemeral: true });
+                return;
+            }
+
+            collector.stop();
+            if (i.customId === 'confirm-assign') {
+                await i.update({ content: `Assigning role \`@${roleToAssign.name}\` to **${targetMembers.size}** members... This may take a moment.`, components: [] });
+
+                let successCount = 0;
+                let failCount = 0;
+
+                for (const member of targetMembers.values()) {
+                    try {
+                        await member.roles.add(roleToAssign);
+                        successCount++;
+                    } catch (err) {
+                        console.error(`Failed to assign role to ${member.user.tag}:`, err);
+                        failCount++;
+                    }
+                }
+
+                await i.editReply({ content: `**Operation Complete!**\n- Successfully assigned role to **${successCount}** members.\n- Failed to assign role to **${failCount}** members.` });
+
+            } else if (i.customId === 'cancel-assign') {
+                await i.update({ content: 'Operation cancelled.', components: [] });
+            }
+        });
+
+        collector.on('end', (collected, reason) => {
+            if (reason === 'time') {
+                interaction.editReply({ content: 'Confirmation timed out. No roles were assigned.', components: [] });
+            }
+        });
+    }
+  },
+};


### PR DESCRIPTION
This commit introduces two major features based on the "Ritsu v2" design document: a declarative server build command and the foundation for a bulk role assignment command.

**/build Command Features:**
- A `/build apply` command that reads a server configuration from `template.json`.
- Pre-execution validation to check for bot permissions and role hierarchy.
- A detailed dry-run preview showing a diff of all proposed changes.
- Execution of changes in the correct dependency order (roles, categories, channels).
- Full support for creating/updating roles, categories, channels, and permission overwrites.
- A snapshot-based rollback system, available via an "Undo" button after a successful build.

**/role Command Features:**
- A new `/role assign-bulk` command.
- A basic filter that allows assigning a role to all members who have another specific role.
- A confirmation step showing the number of affected members before execution.

**Infrastructure:**
- Adds `Template`, `BuildRun`, and `Segment` models to the Prisma schema with clean migrations.
- Establishes a service-oriented architecture for handling diffing, execution, validation, and rollbacks.
- Implements a singleton pattern for the Prisma client.