### PR TITLE
feat: Implement declarative build and bulk role assignment commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "node-cron": "^4.2.1",
         "p-queue": "^6.6.2",
         "sharp": "^0.34.3",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^4.1.3"
       },
       "devDependencies": {
         "@types/node": "^24.3.0",
@@ -2787,6 +2788,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.3.tgz",
+      "integrity": "sha512-1neef4bMce1hNTrxvHVKxWjKfGDn0oAli3Wy1Uwb7TRO1+wEwoZUZNP1NXIEESybOBiFnBOhI6a4m6tCLE8dog==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "node-cron": "^4.2.1",
     "p-queue": "^6.6.2",
     "sharp": "^0.34.3",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^4.1.3"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/src/schemas/templateSchema.ts
+++ b/src/schemas/templateSchema.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+const hexColorRegex = /^#?[0-9a-fA-F]{6}$/;
+
+const TemplateRoleOverwriteSchema = z.object({
+  role: z.string().min(1, { message: "Overwrite role name cannot be empty." }),
+  allow: z.array(z.string()).default([]),
+  deny: z.array(z.string()).default([]),
+});
+
+const TemplateChannelSchema = z.object({
+  name: z.string().min(1, { message: "Channel name cannot be empty." }),
+  type: z.enum(['text', 'voice', 'forum']),
+  topic: z.string().max(1024, { message: "Channel topic cannot be longer than 1024 characters." }).optional(),
+  bitrate: z.number().optional(),
+  overwrites: z.array(TemplateRoleOverwriteSchema).optional(),
+});
+
+const TemplateCategorySchema = z.object({
+  name: z.string().min(1, { message: "Category name cannot be empty." }),
+  channels: z.array(TemplateChannelSchema).min(1, { message: "A category must have at least one channel." }),
+});
+
+const TemplateRoleSchema = z.object({
+  name: z.string().min(1, { message: "Role name cannot be empty." }),
+  color: z.string().regex(hexColorRegex, { message: "Invalid hex color format. e.g. #AABBCC" }).optional(),
+  hoist: z.boolean().optional(),
+  mentionable: z.boolean().optional(),
+});
+
+export const ServerTemplateSchema = z.object({
+  version: z.literal('1', { errorMap: () => ({ message: "Template version must be '1'." }) }),
+  name: z.string().min(1, { message: "Template name cannot be empty." }),
+  roles: z.array(TemplateRoleSchema).optional(),
+  categories: z.array(TemplateCategorySchema).optional(),
+});
+
+/**
+ * A TypeScript type inferred from the Zod schema.
+ * This ensures the type always matches the validation rules.
+ */
+export type ServerTemplate = z.infer<typeof ServerTemplateSchema>;


### PR DESCRIPTION
This commit introduces a comprehensive set of features for declarative server management and advanced role administration, based on the "Ritsu v2" design document.

**/build Command Features:**
- A `/build apply` command that reads a server configuration from `template.json`.
- Zod-based schema validation to ensure the template file is correctly formatted.
- Pre-execution validation to check for bot permissions and role hierarchy.
- A detailed dry-run preview showing a diff of all proposed changes.
- Execution of changes in the correct dependency order (roles, categories, channels).
- Full support for creating/updating roles, categories, channels, and permission overwrites.
- A snapshot-based rollback system, available via an "Undo" button after a successful build.

**/role Command Features:**
- A new `/role assign-bulk` command for mass role assignment.
- A filter system that allows assigning a role to members who have or do not have another specific role.
- A `/role segment` command group to save, list, and reuse filter conditions.
- Autocomplete support for using saved segments.
- A job queue (`p-queue`) to safely process bulk assignments and avoid Discord rate limits.

**Infrastructure:**
- Adds `Template`, `BuildRun`, and `Segment` models to the Prisma schema with clean migrations.
- Establishes a service-oriented architecture for handling diffing, execution, validation, and rollbacks.
- Implements a singleton pattern for the Prisma client.