### PR TITLE
feat: サーバーごとの設定をデータベースに移行

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,3 +90,20 @@ model Segment {
 
   @@index([guildId])
 }
+
+// 新しく追加
+model GuildConfig {
+  id                String    @id @default(cuid())
+  guildId           String    @unique // DiscordサーバーのID
+
+  // ユーザーが設定する項目
+  reminderChannelId String?   // ? をつけて、設定がなくても良い項目にする
+  notionDatabaseId  String?
+  googleCalendarId  String?
+  googleSheetId     String?
+  festivalStartDate DateTime?
+  expenseFormUrl    String?
+
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,135 @@
+import { SlashCommandBuilder, CommandInteraction, PermissionFlagsBits, ChannelType } from 'discord.js';
+import prisma from '../prisma'; // Prismaクライアントをインポート
+import { z } from 'zod';
+
+// 日付形式 (YYYY-MM-DD) を検証するためのZodスキーマ
+const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "日付はYYYY-MM-DD形式で入力してください。");
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('config')
+    .setDescription('サーバーごとのBot設定を管理します。')
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator) // 管理者のみ
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('reminder')
+        .setDescription('イベントリマインダーを投稿するチャンネルを設定します。')
+        .addChannelOption(option =>
+          option.setName('channel')
+            .setDescription('通知チャンネル')
+            .setRequired(true)
+            .addChannelTypes(ChannelType.GuildText) // テキストチャンネルのみに限定
+        )
+    )
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('calendar')
+        .setDescription('GoogleカレンダーのIDを設定します。')
+        .addStringOption(option => option.setName('id').setDescription('カレンダーID').setRequired(true))
+    )
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('notion')
+        .setDescription('NotionデータベースのIDを設定します。')
+        .addStringOption(option => option.setName('id').setDescription('データベースID').setRequired(true))
+    )
+    .addSubcommand(subcommand =>
+        subcommand
+          .setName('sheet')
+          .setDescription('会計報告用のGoogleスプレッドシートのIDを設定します。')
+          .addStringOption(option => option.setName('id').setDescription('スプレッドシートID').setRequired(true))
+    )
+    .addSubcommand(subcommand =>
+        subcommand
+          .setName('startdate')
+          .setDescription('文化祭の開始日を設定します (YYYY-MM-DD)。')
+          .addStringOption(option => option.setName('date').setDescription('開始日 (例: 2025-10-25)').setRequired(true))
+    )
+    .addSubcommand(subcommand =>
+        subcommand
+          .setName('expenseform')
+          .setDescription('経費報告フォームのURLを設定します。')
+          .addStringOption(option => option.setName('url').setDescription('フォームのURL').setRequired(true))
+    ),
+
+  async execute(interaction: CommandInteraction) {
+    if (!interaction.isChatInputCommand() || !interaction.inGuild()) return;
+
+    const subcommand = interaction.options.getSubcommand();
+    const guildId = interaction.guildId;
+
+    try {
+      switch (subcommand) {
+        case 'reminder': {
+          const channel = interaction.options.getChannel('channel', true);
+          await prisma.guildConfig.upsert({
+            where: { guildId },
+            update: { reminderChannelId: channel.id },
+            create: { guildId, reminderChannelId: channel.id },
+          });
+          await interaction.reply({ content: `✅ リマインダーチャンネルを <#${channel.id}> に設定しました。`, ephemeral: true });
+          break;
+        }
+        case 'calendar': {
+          const calendarId = interaction.options.getString('id', true);
+          await prisma.guildConfig.upsert({
+            where: { guildId },
+            update: { googleCalendarId: calendarId },
+            create: { guildId, googleCalendarId: calendarId },
+          });
+          await interaction.reply({ content: `✅ GoogleカレンダーIDを設定しました。`, ephemeral: true });
+          break;
+        }
+        case 'notion': {
+            const notionId = interaction.options.getString('id', true);
+            await prisma.guildConfig.upsert({
+              where: { guildId },
+              update: { notionDatabaseId: notionId },
+              create: { guildId, notionDatabaseId: notionId },
+            });
+            await interaction.reply({ content: `✅ NotionデータベースIDを設定しました。`, ephemeral: true });
+            break;
+        }
+        case 'sheet': {
+            const sheetId = interaction.options.getString('id', true);
+            await prisma.guildConfig.upsert({
+              where: { guildId },
+              update: { googleSheetId: sheetId },
+              create: { guildId, googleSheetId: sheetId },
+            });
+            await interaction.reply({ content: `✅ GoogleスプレッドシートIDを設定しました。`, ephemeral: true });
+            break;
+        }
+        case 'startdate': {
+            const dateStr = interaction.options.getString('date', true);
+            const validation = dateSchema.safeParse(dateStr);
+            if (!validation.success) {
+                await interaction.reply({ content: `❌ 無効な日付形式です。YYYY-MM-DD形式で入力してください。`, ephemeral: true });
+                return;
+            }
+            const startDate = new Date(dateStr);
+            await prisma.guildConfig.upsert({
+              where: { guildId },
+              update: { festivalStartDate: startDate },
+              create: { guildId, festivalStartDate: startDate },
+            });
+            await interaction.reply({ content: `✅ 文化祭開始日を ${dateStr} に設定しました。`, ephemeral: true });
+            break;
+        }
+        case 'expenseform': {
+            const url = interaction.options.getString('url', true);
+            await prisma.guildConfig.upsert({
+              where: { guildId },
+              update: { expenseFormUrl: url },
+              create: { guildId, expenseFormUrl: url },
+            });
+            await interaction.reply({ content: `✅ 経費報告フォームのURLを設定しました。`, ephemeral: true });
+            break;
+        }
+      }
+    } catch (error) {
+        console.error('Config command error:', error);
+        await interaction.reply({ content: '設定の保存中にエラーが発生しました。', ephemeral: true });
+    }
+  },
+};

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,43 +1,61 @@
 import { Client, TextChannel } from 'discord.js';
 import cron from 'node-cron';
 import { getCalendarEvents } from './utils/googleCalendar';
+import prisma from './prisma';
 
-const REMINDER_CHANNEL_ID = process.env.REMINDER_CHANNEL_ID;
 const REMINDER_MINUTES_BEFORE = 15;
 
-const remindedEventIds = new Set<string>();
+// イベントIDがどのギルドでリマインドされたかを記録する
+// これにより、同じイベントが複数のギルドでリマインドされるのを防ぐ
+const remindedEventGuilds = new Map<string, Set<string>>();
 
 async function checkEventsAndSendReminders(client: Client) {
-  if (!REMINDER_CHANNEL_ID) {
-    console.warn('REMINDER_CHANNEL_ID not set. Skipping reminders.');
-    return;
-  }
+  // すべてのサーバー設定を取得
+  const configs = await prisma.guildConfig.findMany();
 
-  const { events, error } = await getCalendarEvents();
-  if (error || !events) {
-    console.error('Could not fetch calendar events for reminder:', error);
-    return;
-  }
+  // 設定があるサーバーごとにループ処理
+  for (const config of configs) {
+    if (!config.reminderChannelId || !config.googleCalendarId) {
+      continue; // チャンネルやカレンダーが設定されていなければスキップ
+    }
 
-  const now = new Date();
-  const reminderTimeLimit = new Date(now.getTime() + REMINDER_MINUTES_BEFORE * 60 * 1000);
-
-  for (const event of events) {
-    if (!event.id || !event.start?.dateTime || remindedEventIds.has(event.id)) {
+    // データベースから取得したカレンダーIDを使う
+    const { events, error } = await getCalendarEvents(config.googleCalendarId);
+    if (error || !events) {
+      console.error(`Could not fetch calendar events for guild ${config.guildId}:`, error);
       continue;
     }
 
-    const eventStartTime = new Date(event.start.dateTime);
-    if (eventStartTime > now && eventStartTime <= reminderTimeLimit) {
-      try {
-        const channel = await client.channels.fetch(REMINDER_CHANNEL_ID);
-        if (channel && channel instanceof TextChannel) {
-          const time = eventStartTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
-          await channel.send(`【まもなく開始！】 **${time}** から **${event.summary}** が始まります！ @everyone`);
-          remindedEventIds.add(event.id);
+    const now = new Date();
+    const reminderTimeLimit = new Date(now.getTime() + REMINDER_MINUTES_BEFORE * 60 * 1000);
+
+    for (const event of events) {
+      if (!event.id || !event.start?.dateTime) {
+        continue;
+      }
+
+      // このギルドでこのイベントが既にリマインド済みかチェック
+      if (remindedEventGuilds.get(event.id)?.has(config.guildId)) {
+        continue;
+      }
+
+      const eventStartTime = new Date(event.start.dateTime);
+      if (eventStartTime > now && eventStartTime <= reminderTimeLimit) {
+        try {
+          const channel = await client.channels.fetch(config.reminderChannelId);
+          if (channel instanceof TextChannel) {
+            const time = eventStartTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+            await channel.send(`【まもなく開始！】 **${time}** から **${event.summary}** が始まります！ @everyone`);
+
+            // リマインド済みとして記録
+            if (!remindedEventGuilds.has(event.id)) {
+              remindedEventGuilds.set(event.id, new Set());
+            }
+            remindedEventGuilds.get(event.id)?.add(config.guildId);
+          }
+        } catch (e) {
+          console.error(`Failed to send reminder for guild ${config.guildId}:`, e);
         }
-      } catch (e) {
-        console.error('Failed to send reminder:', e);
       }
     }
   }

--- a/src/utils/googleCalendar.ts
+++ b/src/utils/googleCalendar.ts
@@ -1,11 +1,9 @@
 import { google } from 'googleapis';
 
-const GOOGLE_CALENDAR_ID = process.env.GOOGLE_CALENDAR_ID;
-
 // Helper to get calendar events
-export async function getCalendarEvents() {
-  if (!GOOGLE_CALENDAR_ID || !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-    return { error: 'Google Calendar not configured.' };
+export async function getCalendarEvents(calendarId: string) {
+  if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return { error: 'Google Calendar credentials not configured.' };
   }
   try {
     const auth = new google.auth.GoogleAuth({
@@ -20,7 +18,7 @@ export async function getCalendarEvents() {
     tomorrow.setDate(tomorrow.getDate() + 1);
 
     const res = await calendar.events.list({
-      calendarId: GOOGLE_CALENDAR_ID,
+      calendarId: calendarId,
       timeMin: today.toISOString(),
       timeMax: tomorrow.toISOString(),
       singleEvents: true,


### PR DESCRIPTION
サーバーごとの設定（リマインダーチャンネル、各種API IDなど）を.envファイルからデータベース（Prisma）に保存するように変更しました。

- `GuildConfig`モデルを`schema.prisma`に追加
- サーバー管理者が設定を変更するための`/config`コマンドを新規作成
- 既存のコマンド（`/countdown`, `/finance`, `/submit`など）とスケジューラーが、環境変数の代わりにデータベースからギルド固有の設定を読み込むようにリファクタリング

これにより、Botが複数のDiscordサーバーでそれぞれ異なる設定を持って同時に動作できるようになります。