### PR TITLE
Fix: Resolve bot initialization failures and add ping command

### DIFF
--- a/src/commands/achievements.ts
+++ b/src/commands/achievements.ts
@@ -1,7 +1,5 @@
 import { SlashCommandBuilder, CommandInteraction, EmbedBuilder } from 'discord.js';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import getPrisma from '../prisma';
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -24,6 +22,7 @@ module.exports = {
       try {
         await interaction.deferReply();
 
+        const prisma = getPrisma();
         const [kudosGiven, kudosReceived, itemsReported, shiftCount] = await Promise.all([
           prisma.kudos.count({ where: { fromUserId: targetUser.id } }),
           prisma.kudos.count({ where: { toUserId: targetUser.id } }),

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -1,9 +1,8 @@
 import { SlashCommandBuilder, CommandInteraction, PermissionFlagsBits } from 'discord.js';
-import { PrismaClient } from '@prisma/client';
+import getPrisma from '../prisma';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import * as kuromoji from 'kuromoji';
 
-const prisma = new PrismaClient();
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '');
 
 // --- Kuromoji Tokenizer Initialization ---
@@ -40,6 +39,7 @@ module.exports = {
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand()) return;
 
+    const prisma = getPrisma();
     const subcommand = interaction.options.getSubcommand();
 
     try {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,5 @@
 import { SlashCommandBuilder, CommandInteraction, PermissionFlagsBits, ChannelType } from 'discord.js';
-import prisma from '../prisma'; // Prismaクライアントをインポート
+import getPrisma from '../prisma'; // Prismaクライアントをインポート
 import { z } from 'zod';
 
 // 日付形式 (YYYY-MM-DD) を検証するためのZodスキーマ
@@ -31,6 +31,7 @@ module.exports = {
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand() || !interaction.inGuild()) return;
 
+    const prisma = getPrisma();
     const subcommand = interaction.options.getSubcommand();
     const guildId = interaction.guildId;
 

--- a/src/commands/congestion.ts
+++ b/src/commands/congestion.ts
@@ -1,9 +1,7 @@
 import { SlashCommandBuilder, CommandInteraction, EmbedBuilder, PermissionFlagsBits, AttachmentBuilder } from 'discord.js';
-import { PrismaClient } from '@prisma/client';
+import getPrisma from '../prisma';
 import sharp from 'sharp';
 import path from 'path';
-
-const prisma = new PrismaClient();
 
 // --- Configuration ---
 // Using path.resolve to ensure the path is correct regardless of execution context.
@@ -58,6 +56,7 @@ module.exports = {
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand()) return;
     const subcommand = interaction.options.getSubcommand();
+    const prisma = getPrisma();
 
     try {
       if (subcommand === 'report') {

--- a/src/commands/countdown.ts
+++ b/src/commands/countdown.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder, CommandInteraction, EmbedBuilder } from 'discord.js';
 import { fromZonedTime } from 'date-fns-tz';
-import prisma from '../prisma';
+import getPrisma from '../prisma';
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -12,6 +12,7 @@ module.exports = {
         return;
     }
 
+    const prisma = getPrisma();
     const config = await prisma.guildConfig.findUnique({
         where: { guildId: interaction.guildId },
     });

--- a/src/commands/inventory.ts
+++ b/src/commands/inventory.ts
@@ -1,7 +1,5 @@
 import { SlashCommandBuilder, CommandInteraction, EmbedBuilder, PermissionFlagsBits } from 'discord.js';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import getPrisma from '../prisma';
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -38,6 +36,7 @@ module.exports = {
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand()) return;
 
+    const prisma = getPrisma();
     const subcommand = interaction.options.getSubcommand();
     const name = interaction.options.getString('name');
     const quantity = interaction.options.getInteger('quantity');

--- a/src/commands/kudos.ts
+++ b/src/commands/kudos.ts
@@ -1,7 +1,5 @@
 import { SlashCommandBuilder, CommandInteraction, EmbedBuilder } from 'discord.js';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import getPrisma from '../prisma';
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -22,6 +20,7 @@ module.exports = {
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand()) return;
 
+    const prisma = getPrisma();
     const subcommand = interaction.options.getSubcommand();
 
     try {

--- a/src/commands/lostfound.ts
+++ b/src/commands/lostfound.ts
@@ -1,7 +1,5 @@
 import { SlashCommandBuilder, CommandInteraction, EmbedBuilder, PermissionFlagsBits } from 'discord.js';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import getPrisma from '../prisma';
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -30,6 +28,7 @@ module.exports = {
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand()) return;
 
+    const prisma = getPrisma();
     const subcommand = interaction.options.getSubcommand();
 
     try {

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,0 +1,8 @@
+import { SlashCommandBuilder, CommandInteraction } from 'discord.js';
+
+module.exports = {
+  data: new SlashCommandBuilder().setName('ping').setDescription('Botの疎通確認'),
+  async execute(interaction: CommandInteraction) {
+    await interaction.reply('pong!');
+  },
+};

--- a/src/commands/role.ts
+++ b/src/commands/role.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder, CommandInteraction, Role, GuildMember, ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType, EmbedBuilder, AutocompleteInteraction, ChatInputCommandInteraction } from 'discord.js';
 import { filterMembers } from '../services/filterService';
-import prisma from '../prisma';
+import getPrisma from '../prisma';
 import PQueue from 'p-queue';
 
 module.exports = {
@@ -44,6 +44,7 @@ module.exports = {
             )
     ),
   async autocomplete(interaction: AutocompleteInteraction) {
+    const prisma = getPrisma();
     const focusedOption = interaction.options.getFocused(true);
     if (focusedOption.name === 'segment') {
         const segments = await prisma.segment.findMany({
@@ -64,6 +65,7 @@ module.exports = {
   async execute(interaction: ChatInputCommandInteraction) {
     if (!interaction.guild) return;
 
+    const prisma = getPrisma();
     const group = interaction.options.getSubcommandGroup();
 
     if (group === 'segment') {

--- a/src/commands/shift.ts
+++ b/src/commands/shift.ts
@@ -1,7 +1,5 @@
 import { SlashCommandBuilder, CommandInteraction, EmbedBuilder } from 'discord.js';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import getPrisma from '../prisma';
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -30,6 +28,7 @@ module.exports = {
   async execute(interaction: CommandInteraction) {
     if (!interaction.isChatInputCommand()) return;
 
+    const prisma = getPrisma();
     const subcommand = interaction.options.getSubcommand();
 
     try {
@@ -55,8 +54,8 @@ module.exports = {
           return;
         }
         const embed = new EmbedBuilder().setColor('#FFC300').setTitle('Shift Roster');
-        shifts.forEach(shift => {
-          const assignees = shift.assignees.map(user => user.tag || user.id).join(', ') || 'None';
+        shifts.forEach((shift) => {
+          const assignees = shift.assignees.map((user: { tag: string | null; id: string }) => user.tag || user.id).join(', ') || 'None';
           embed.addFields({
             name: `${shift.name} @ ${shift.location} (${shift.time})`,
             value: `**ID:** ${shift.id}\n**Assigned:** ${assignees}`,

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,9 +1,14 @@
 import { PrismaClient } from '@prisma/client';
 
-/**
- * A singleton instance of the Prisma Client.
- * This should be used throughout the application to interact with the database.
- */
-const prisma = new PrismaClient();
+let prisma: PrismaClient | null = null;
 
-export default prisma;
+/**
+ * Returns a singleton instance of the Prisma Client.
+ * The instance is created on the first call.
+ */
+export default function getPrisma() {
+  if (!prisma) {
+    prisma = new PrismaClient();
+  }
+  return prisma;
+}

--- a/src/services/executionService.ts
+++ b/src/services/executionService.ts
@@ -1,5 +1,5 @@
 import { ChannelType, Guild, OverwriteResolvable, PermissionsString } from 'discord.js';
-import prisma from '../prisma';
+import getPrisma from '../prisma';
 import { TemplateRoleOverwrite } from '../types/template';
 import { DiffResult } from './diffService';
 import { GuildState } from './discordService';
@@ -35,6 +35,7 @@ async function mapOverwrites(guild: Guild, templateOverwrites: TemplateRoleOverw
  * Executes the changes determined by the diffing service and returns the build run record.
  */
 export async function executeBuild(guild: Guild, diff: DiffResult, currentState: GuildState, templateName: string, userId: string) {
+    const prisma = getPrisma();
     const buildRun = await prisma.buildRun.create({
         data: {
             templateName: templateName,

--- a/src/services/rollbackService.ts
+++ b/src/services/rollbackService.ts
@@ -1,5 +1,5 @@
 import { Guild, OverwriteResolvable, PermissionsString } from 'discord.js';
-import prisma from '../prisma';
+import getPrisma from '../prisma';
 import { DiffResult } from './diffService';
 import { SimpleOverwrite } from './discordService';
 
@@ -29,6 +29,7 @@ async function mapOverwritesFromSnapshot(guild: Guild, snapshotOverwrites: Simpl
  * @param guild The guild where the rollback should occur.
  */
 export async function executeRollback(buildRunId: string, guild: Guild) {
+    const prisma = getPrisma();
     const buildRun = await prisma.buildRun.findUnique({ where: { id: buildRunId } });
 
     if (!buildRun) throw new Error('Build run not found.');


### PR DESCRIPTION
This commit addresses several critical issues that prevented the bot from starting correctly and its commands from being registered.

The main changes include:

- **Lazy Prisma Initialization**: Refactored the Prisma Client instantiation to a lazy-loading pattern using a `getPrisma()` singleton factory. This prevents the `deploy-commands.ts` script from crashing on startup due to database connection issues. All commands and services that use Prisma have been updated to this new pattern.

- **Zod v4 Compatibility**: Corrected the error handling in `templateService.ts` to use `error.issues` instead of the deprecated `error.errors`, aligning it with Zod v4.

- **Type Safety**: Fixed implicit `any` type errors in `shift.ts` that were caught by the TypeScript compiler, improving overall type safety.

- **Added /ping Command**: Introduced a new, simple `/ping` command. This serves as a basic health check to confirm that the bot is responsive and that slash commands are being registered and processed correctly.