### PR TITLE
feat: Add Zod schema validation for template files

### DIFF
--- a/src/schemas/templateSchema.ts
+++ b/src/schemas/templateSchema.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod';
+import { PermissionFlagsBits } from 'discord.js';
+
+// Dynamically create a Zod enum from the keys of PermissionFlagsBits
+const permissionNames = Object.keys(PermissionFlagsBits) as (keyof typeof PermissionFlagsBits)[];
+const PermissionStringSchema = z.enum(permissionNames);
 
 const hexColorRegex = /^#?[0-9a-fA-F]{6}$/;
 
 const TemplateRoleOverwriteSchema = z.object({
   role: z.string().min(1, { message: "Overwrite role name cannot be empty." }),
-  allow: z.array(z.string()).default([]),
-  deny: z.array(z.string()).default([]),
+  allow: z.array(PermissionStringSchema).default([]),
+  deny: z.array(PermissionStringSchema).default([]),
 });
 
 const TemplateChannelSchema = z.object({


### PR DESCRIPTION
This commit enhances the security and robustness of the `/build` command by introducing strict validation for `template.json` using a Zod schema.

- A detailed Zod schema is defined in `src/schemas/templateSchema.ts` to model the structure of the template file.
- The schema for permission overwrites now validates against a dynamically generated enum of all valid `PermissionFlagsBits` from `discord.js`, preventing the use of invalid permission strings and mitigating risks of unintended permission escalation.
- The existing `templateService.ts` automatically integrates this more robust schema, ensuring all loaded templates are validated against these stricter rules.