### PR TITLE
feat: improve command loading

### DIFF
--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -7,12 +7,20 @@ import logger from './logger';
 
 const commands: any[] = [];
 const commandsDir = path.join(__dirname, 'commands');
-for (const file of fs.readdirSync(commandsDir).filter(f => f.endsWith('.ts') || f.endsWith('.js'))) {
+for (const file of fs
+  .readdirSync(commandsDir)
+  .filter((f) => f.endsWith('.ts') || f.endsWith('.js'))
+) {
   const filePath = path.join(commandsDir, file);
   try {
-    const c = require(filePath);
-    if (c?.data?.toJSON) commands.push(c.data.toJSON());
-    else logger.warn({ filePath }, 'Skip: no data.toJSON');
+    const imported = require(filePath);
+    const c = imported.default ?? imported;
+    if (c?.data?.toJSON) {
+      commands.push(c.data.toJSON());
+      logger.info({ command: c.data.name }, 'Prepared command for deploy');
+    } else {
+      logger.warn({ filePath }, 'Skip: no data.toJSON');
+    }
   } catch (err) {
     logger.error({ err, filePath }, 'Skip broken command on deploy');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,12 +20,20 @@ const client = new Client({
 client.commands = new Collection<string, Command>();
 
 const commandsPath = path.join(__dirname, 'commands');
-for (const file of fs.readdirSync(commandsPath).filter(f => f.endsWith('.ts') || f.endsWith('.js'))) {
+for (const file of fs
+  .readdirSync(commandsPath)
+  .filter((f) => f.endsWith('.ts') || f.endsWith('.js'))
+) {
   const filePath = path.join(commandsPath, file);
   try {
-    const cmd: Command = require(filePath);
-    if (cmd?.data?.name && typeof cmd.execute === 'function') client.commands.set(cmd.data.name, cmd);
-    else logger.warn({ filePath }, 'Invalid command module shape, skipped');
+    const imported = require(filePath);
+    const cmd: Command = (imported.default ?? imported) as Command;
+    if (cmd?.data?.name && typeof cmd.execute === 'function') {
+      client.commands.set(cmd.data.name, cmd);
+      logger.info({ command: cmd.data.name }, 'Loaded command');
+    } else {
+      logger.warn({ filePath }, 'Invalid command module shape, skipped');
+    }
   } catch (err) {
     logger.error({ err, filePath }, 'Failed to load command (skipped)');
   }


### PR DESCRIPTION
## Summary
- allow command loader to support default exports
- log loaded commands for easier debug

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af202493748327b14dfdf802b09f29